### PR TITLE
fix: bouclier defensif aggro overcounting + offrande vitale armor tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,21 @@ cargo clippy --all-targets
 cargo test
 ```
 
-All 165 tests should pass with no warnings.
+All 233 tests should pass with no warnings.
+
+---
+
+## Bug Fixes
+
+### Bouclier Défensif — aggro overcounting (+42 instead of +40)
+
+**Root cause:** An `else` branch in `apply_processed_effect_param` generated implicit aggro from any `ChangeCurrentStatByValue` effect on a non-HP, non-Aggro stat. Bouclier Défensif applies Berserk +30, which rounded to 2 extra aggro, giving 42 total.
+
+**Fix:** Removed the `else` branch. Only HP changes (heals/damage) and explicit Aggro stat effects now generate aggro.
+
+### Offrande vitale — apparent lack of armor buff impact
+
+The +50% magic/physical armor buff on the target is applied correctly: `set_stats_on_effect` updates `buf_effect_percent` and `recompute_stat_max_and_current` raises the max from 50 → 75. The limited visible damage reduction (~2%) is by design — the armor formula `1000 / (1000 + armor)` yields diminishing returns at low armor values.
 
 ---
 

--- a/src/character_mod/character.rs
+++ b/src/character_mod/character.rs
@@ -486,12 +486,9 @@ impl Character {
                 // Explicit aggro effects bypass the /20 normalisation so the full value
                 // is tracked in tx_rx and persists across NB_TURN_SUM_AGGRO turns.
                 aggro_generated = processed_ep.input_effect_param.buffer.value.unsigned_abs();
-            } else {
-                let v = processed_ep.input_effect_param.buffer.value.abs() as f64;
-                if v > 0.0 {
-                    aggro_generated = (v / aggro_norm).round() as u64;
-                }
             }
+            // Non-HP, non-Aggro stat effects (Berserk, Dodge, etc.) do not generate
+            // implicit aggro; only HP changes and explicit Aggro effects do.
         }
 
         // update stats in game

--- a/src/server/game_manager.rs
+++ b/src/server/game_manager.rs
@@ -3426,4 +3426,126 @@ mod tests {
             "all heroes dead → EndOfGame"
         );
     }
+
+    /// Offrande vitale must boost Thraïn's magical and physical armor max by +50%.
+    #[test]
+    fn unit_offrande_vitale_buffs_thrain_armor() {
+        use crate::testing::testing_all_characters::dxrpg_game_manager;
+
+        let mut gm = dxrpg_game_manager();
+        gm.start_game();
+
+        // Advance to Elara's turn
+        let mut max_setup = 30;
+        while !gm.pm.current_player.id_name.contains("Elara") && max_setup > 0 {
+            gm.new_round();
+            max_setup -= 1;
+        }
+        if !gm.pm.current_player.id_name.contains("Elara") {
+            return;
+        }
+
+        gm.pm.current_player.stats.all_stats[CRITICAL_STRIKE].current = 0;
+        let mana_max = gm.pm.current_player.stats.all_stats[MANA].max;
+        gm.pm.current_player.stats.all_stats[MANA].current = mana_max;
+
+        let thrain_id = gm
+            .pm
+            .active_heroes
+            .iter()
+            .find(|h| h.id_name.contains("Thraïn"))
+            .map(|h| h.id_name.clone())
+            .expect("Thraïn must be present");
+
+        let old_mag_armor = gm
+            .pm
+            .get_active_hero_character(&thrain_id)
+            .unwrap()
+            .stats
+            .all_stats[MAGICAL_ARMOR]
+            .max;
+        let old_phy_armor = gm
+            .pm
+            .get_active_hero_character(&thrain_id)
+            .unwrap()
+            .stats
+            .all_stats[PHYSICAL_ARMOR]
+            .max;
+
+        // Offrande vitale targets a single ally — manually mark Thraïn as the current target.
+        gm.pm
+            .get_mut_active_hero_character(&thrain_id)
+            .unwrap()
+            .character_rounds_info
+            .is_current_target = true;
+
+        gm.launch_attack(Some("Offrande vitale"));
+
+        let new_mag_armor = gm
+            .pm
+            .get_active_hero_character(&thrain_id)
+            .unwrap()
+            .stats
+            .all_stats[MAGICAL_ARMOR]
+            .max;
+        let new_phy_armor = gm
+            .pm
+            .get_active_hero_character(&thrain_id)
+            .unwrap()
+            .stats
+            .all_stats[PHYSICAL_ARMOR]
+            .max;
+
+        assert_eq!(
+            old_mag_armor + old_mag_armor * 50 / 100,
+            new_mag_armor,
+            "Offrande vitale must boost Thraïn magic armor max by 50%"
+        );
+        assert_eq!(
+            old_phy_armor + old_phy_armor * 50 / 100,
+            new_phy_armor,
+            "Offrande vitale must boost Thraïn physical armor max by 50%"
+        );
+    }
+
+    /// Bouclier Défensif must give exactly +40 aggro to Thraïn (not +42 from implicit Berserk aggro).
+    #[test]
+    fn unit_bouclier_defensif_exact_aggro() {
+        use crate::testing::testing_all_characters::dxrpg_game_manager;
+
+        let mut gm = dxrpg_game_manager();
+        gm.start_game();
+
+        // Advance to Thraïn's turn
+        let mut max_setup = 30;
+        while !gm.pm.current_player.id_name.contains("Thraïn") && max_setup > 0 {
+            gm.new_round();
+            max_setup -= 1;
+        }
+        if !gm.pm.current_player.id_name.contains("Thraïn") {
+            return;
+        }
+
+        gm.pm.current_player.stats.all_stats[CRITICAL_STRIKE].current = 0;
+
+        let thrain_id = gm.pm.current_player.id_name.clone();
+        let aggro_before = gm.pm.current_player.stats.all_stats[AGGRO].current;
+
+        // Bouclier Défensif targets Self — no explicit target setting needed.
+        gm.launch_attack(Some("Bouclier Défensif "));
+
+        let aggro_after = gm
+            .pm
+            .get_active_hero_character(&thrain_id)
+            .unwrap()
+            .stats
+            .all_stats[AGGRO]
+            .current;
+
+        assert_eq!(
+            aggro_before + 40,
+            aggro_after,
+            "Bouclier Défensif must give exactly +40 aggro (not inflated by Berserk implicit aggro)"
+        );
+    }
 }


### PR DESCRIPTION
Bouclier Defensif was granting +42 aggro instead of +40 because an else branch in apply_processed_effect_param generated implicit aggro from any ChangeCurrentStatByValue effect, including Berserk +30 (rounded to 2). Removed that branch so only HP changes and explicit Aggro effects generate aggro.

Added unit tests for both attacks:
- unit_bouclier_defensif_exact_aggro: asserts exactly +40 aggro
- unit_offrande_vitale_buffs_thrain_armor: asserts +50% magic/physical armor max on target

Updated README with bug descriptions and test count (165 → 233).

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  nothing yet hehe
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  nothing yet hehe
-->
