### PR TITLE
update scenario flow by removing regen at end of scenario

### DIFF
--- a/src/server/game_manager/scenario_flow.rs
+++ b/src/server/game_manager/scenario_flow.rs
@@ -294,7 +294,7 @@ mod tests {
         gm.states_scenarios
             .insert(stage1_name.clone(), ScenarioState::InProgress);
 
-        // damage heroes and drain their energy to verify restoration on next scenario
+        // damage heroes and drain their energy to verify it carries over unchanged into the next scenario
         for hero in gm.pm.active_heroes.iter_mut() {
             hero.stats.get_mut_value(HP).current = 1;
             hero.stats.get_mut_value(MANA).current = 0;
@@ -328,21 +328,21 @@ mod tests {
             "active_bosses should match stage 2 boss patterns count"
         );
 
-        // heroes must have HP, energy and no effects restored to max
+        // heroes must have effects cleared, but HP/Mana/Vigor carry over unchanged
         for hero in gm.pm.active_heroes.iter() {
             assert_eq!(
-                hero.stats.all_stats[HP].current, hero.stats.all_stats[HP].max,
-                "hero {} HP should be restored to max",
+                hero.stats.all_stats[HP].current, 1,
+                "hero {} HP should NOT be restored on scenario transition",
                 hero.db_full_name
             );
             assert_eq!(
-                hero.stats.all_stats[MANA].current, hero.stats.all_stats[MANA].max,
-                "hero {} Mana should be restored to max",
+                hero.stats.all_stats[MANA].current, 0,
+                "hero {} Mana should NOT be restored on scenario transition",
                 hero.db_full_name
             );
             assert_eq!(
-                hero.stats.all_stats[VIGOR].current, hero.stats.all_stats[VIGOR].max,
-                "hero {} Vigor should be restored to max",
+                hero.stats.all_stats[VIGOR].current, 0,
+                "hero {} Vigor should NOT be restored on scenario transition",
                 hero.db_full_name
             );
             assert_eq!(

--- a/src/server/players_manager/mod.rs
+++ b/src/server/players_manager/mod.rs
@@ -85,9 +85,10 @@ impl PlayerManager {
                 stat.current = stat.current.min(stat.max);
             }
             c.character_rounds_info.clear();
-            c.stats.get_mut_value(HP).current = c.stats.all_stats[HP].max;
-            c.stats.get_mut_value(MANA).current = c.stats.all_stats[MANA].max;
-            c.stats.get_mut_value(VIGOR).current = c.stats.all_stats[VIGOR].max;
+            // HP and energies (Mana/Vigor) intentionally carry over across scenarios —
+            // nothing is free-healed/refilled between encounters. Berserk still resets to
+            // 0 (not a max-restore: it's a builds-up-during-combat resource that always
+            // starts empty).
             c.stats.get_mut_value(BERSERK).current = 0;
             c.stats.get_mut_value(SPEED).current = 0;
             // Reset displayed aggro so the new scenario starts from 0.
@@ -340,8 +341,9 @@ mod tests {
         assert_eq!(10, hot_and_dot); // 30(hot) - 20 (dot)
     }
 
-    /// clear_scenario must reset speed to 0, restore stat maxima inflated by active
-    /// ChangeMaxStat* effects (e.g. speed_regen, dodge), and set HP/Mana/Vigor to full.
+    /// clear_scenario must reset speed to 0 and restore stat maxima inflated by active
+    /// ChangeMaxStat* effects (e.g. speed_regen, dodge).
+    /// HP and Mana are intentionally left untouched — they carry over across scenarios.
     #[test]
     fn unit_clear_scenario_resets_stats() {
         use crate::character_mod::{
@@ -354,8 +356,6 @@ mod tests {
 
         let old_dodge_max = pm.active_heroes[0].stats.all_stats[DODGE].max;
         let old_speed_regen_max = pm.active_heroes[0].stats.all_stats[SPEED_REGEN].max;
-        let old_hp_max = pm.active_heroes[0].stats.all_stats[HP].max;
-        let old_mana_max = pm.active_heroes[0].stats.all_stats[MANA].max;
 
         // Inject ChangeMaxStat +20 on Dodge (simulates an active mid-scenario buff).
         let dodge_ep = EffectParam {
@@ -452,12 +452,12 @@ mod tests {
             "Speed regen max must be restored after clear_scenario"
         );
         assert_eq!(
-            old_hp_max, hero.stats.all_stats[HP].current,
-            "HP must be restored to max after clear_scenario"
+            10, hero.stats.all_stats[HP].current,
+            "HP must be left untouched (not restored) by clear_scenario"
         );
         assert_eq!(
-            old_mana_max, hero.stats.all_stats[MANA].current,
-            "Mana must be restored to max after clear_scenario"
+            5, hero.stats.all_stats[MANA].current,
+            "Mana must be left untouched (not restored) by clear_scenario"
         );
         assert_eq!(
             0, hero.stats.all_stats[BERSERK].current,


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  nothing yet hehe
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  nothing yet hehe
-->
